### PR TITLE
Bump actions/setup-node action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 16
           cache: yarn


### PR DESCRIPTION
to `v2`, because I was getting complaints from the actions runner 
![image](https://user-images.githubusercontent.com/755842/152185689-11f93877-d046-453c-82cb-d65480295617.png)
