### PR TITLE
Add rewrap command to docs

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -430,8 +430,8 @@ eg:
 `box wrap blue air`
 Wraps the token containing letter 'a' with a blue hat in square brackets.
 
-The rewrap command can be used to swap a given pair of symbols with another
-- `"curly rewrap <TARGET>"`: wraps the target with curly brackets, replacing the previous paired delimiter
+The rewrap command, mapped to `"repack"` by default, can be used to swap a given pair of symbols with another
+- `"curly repack <TARGET>"`: wraps the target with curly brackets, replacing the previous paired delimiter
 
 See [paired delimiters](#paired-delimiters) for a list of possible wrappers.
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -43,7 +43,7 @@ Note: If you'd like to customize any of the spoken forms, please see the [docume
   - [Rename](#rename)
   - [Scroll](#scroll)
   - [Insert/Use/Repeat](#insertuserepeat)
-  - [Wrap](#wrap)
+  - [Wrap/Rewrap](#wraprewrap)
     - [\[experimental\] Wrap with snippet](#experimental-wrap-with-snippet)
   - [Show definition/reference/quick fix](#show-definitionreferencequick-fix)
   - [Fold/unfold](#foldunfold)
@@ -419,9 +419,9 @@ eg:
 `move blue air to green bat`
 Replaces the token containing letter 'b' with a green hat using the token containing letter 'a' with a blue hat, and the delete the latter token.
 
-### Wrap
+### Wrap/Rewrap
 
-The wrap commands can be used to wrap a given target with a pair of symbols
+The wrap command can be used to wrap a given target with a pair of symbols
 
 - `"round wrap <TARGET>"`: wraps the target with parentheses
 - `"box wrap <TARGET>"`: wraps the target with square brackets
@@ -429,6 +429,9 @@ The wrap commands can be used to wrap a given target with a pair of symbols
 eg:
 `box wrap blue air`
 Wraps the token containing letter 'a' with a blue hat in square brackets.
+
+The rewrap command can be used to swap a given pair of symbols with another
+- `"curly rewrap <TARGET>"`: wraps the target with curly brackets, replacing the previous paired delimiter
 
 See [paired delimiters](#paired-delimiters) for a list of possible wrappers.
 


### PR DESCRIPTION
This adds the rewrap command to the user docs. As an aside, I had a hard time getting it recognized over wrap and had to switch the command to "switch".