### PR TITLE
Support value scope for yield statements in TS and PHP

### DIFF
--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -146,6 +146,7 @@ const nodeMatchers: Partial<Record<ScopeType, NodeMatcherAlternative>> = {
       "assignment_expression[right]",
       "augmented_assignment_expression[right]",
       "return_statement[0]",
+      "yield_expression[0]",
     ],
     assignmentOperators.concat(["=>"]),
   ),

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -159,7 +159,8 @@ const nodeMatchers: Partial<Record<ScopeType, NodeMatcherAlternative>> = {
   collectionItem: argumentMatcher(...mapTypes, ...listTypes),
   value: cascadingMatcher(
     valueMatcher(),
-    patternMatcher("return_statement.~return!")
+    patternMatcher("return_statement.~return!"),
+    patternMatcher("yield_expression.~yield!")
   ),
   ifStatement: "if_statement",
   anonymousFunction: [

--- a/src/test/suite/fixtures/recorded/languages/php/changeValue7.yml
+++ b/src/test/suite/fixtures/recorded/languages/php/changeValue7.yml
@@ -1,0 +1,29 @@
+languageId: php
+command:
+  version: 1
+  spokenForm: change value
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+initialState:
+  documentContents: |-
+    <?php
+
+    yield $value;
+  selections:
+    - anchor: {line: 2, character: 9}
+      active: {line: 2, character: 9}
+  marks: {}
+finalState:
+  documentContents: |-
+    <?php
+
+    yield ;
+  selections:
+    - anchor: {line: 2, character: 6}
+      active: {line: 2, character: 6}
+  thatMark:
+    - anchor: {line: 2, character: 6}
+      active: {line: 2, character: 6}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/languages/php/chuckValue10.yml
+++ b/src/test/suite/fixtures/recorded/languages/php/chuckValue10.yml
@@ -1,0 +1,29 @@
+languageId: php
+command:
+  version: 1
+  spokenForm: chuck value
+  action: remove
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+initialState:
+  documentContents: |-
+    <?php
+
+    yield $value;
+  selections:
+    - anchor: {line: 2, character: 9}
+      active: {line: 2, character: 9}
+  marks: {}
+finalState:
+  documentContents: |-
+    <?php
+
+    yield;
+  selections:
+    - anchor: {line: 2, character: 5}
+      active: {line: 2, character: 5}
+  thatMark:
+    - anchor: {line: 2, character: 5}
+      active: {line: 2, character: 5}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/languages/typescript/changeValue.yml
+++ b/src/test/suite/fixtures/recorded/languages/typescript/changeValue.yml
@@ -1,0 +1,29 @@
+languageId: typescript
+command:
+  version: 1
+  spokenForm: change value
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+initialState:
+  documentContents: |-
+    function* generator(i) {
+      yield i + 10;
+    }
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+  marks: {}
+finalState:
+  documentContents: |-
+    function* generator(i) {
+      yield ;
+    }
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}
+  thatMark:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}, isImplicit: false}]


### PR DESCRIPTION
Fixes #325 

I also slipped in support for PHP since I missed it when I originally added the language.

## Checklist

- [x] I have added [tests](https://github.com/cursorless-dev/cursorless-vscode/blob/main/docs/contributing/test-case-recorder.md)