### PR TITLE
Exclude website from extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,4 @@ node_modules/**
 out/**
 dist/**
 !dist/extension.js
+website/**


### PR DESCRIPTION
Not necessary to ship the website with the extension.  Shouldn't be too big of a deal in CI, but locally packaging extension you end up with massive bundle if you've built website before locally

## Checklist

- [ ] I have added [tests](https://github.com/cursorless-dev/cursorless-vscode/blob/main/docs/contributing/test-case-recorder.md)
